### PR TITLE
json data import and legacy url redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,47 @@
 
 [![Build Status](https://secure.travis-ci.org/silverstripe-labs/silverstripe-sitetreeimporter.png?branch=master)](http://travis-ci.org/silverstripe-labs/silverstripe-sitetreeimporter)
 
-## Maintainer Contact
+## Maintainer Contacts
 
- * Sam Minnee (Nickname: sminnee) 
+ * Sam Minnee (Nickname: sminnee)
    <sam (at) silverstripe (dot) com>
+ * Michael Parkhill
+   <mike (at) silverstripe (dot) com>
 
 ## Requirements
- 
+
  * SilverStripe 3.0 or later
 
 ## Installation
 
 No installation required.
 
-## Usage 
+## Usage
 
-Make a tabbed-out file as directed in the form that appears above. Make sure that you use tabs, not spaces.
-Visit `http://localhost/SiteTreeImporter?flush=1`.
-Select your tabbed-out file in the file field, and tick the other two boxes as appropriate:
+Make a tabbed-out file as directed in the form that appears below. Make sure that you use tabs, not spaces.
+Visit `http://localhost/your-site-name/SiteTreeImporter?flush=1`.
+Select your tabbed-out file in the file field, and tick the option boxes as appropriate:
 
-*Clear out all existing content?* - This will delete everything from your site before running the importer. 
+*Clear out all existing content?*- This will delete everything from your site before running the importer.
 Use with caution! If you don't tick this, then the pages will be added to the existing site.
 
-*Publish everything after the import?* - This will publish each of the pages that the importer creates. 
+*Publish everything after the import?*- This will publish each of the pages that the importer creates.
 If you don't tick this, then the pages will be left as draft-only.
+
+* Clear out all existing Redirected URLs?*- This will delete everything in the RedirectedURL table, use with caution!
+If don't tick this option, you could have duplicate redirects created.
+
+*Create Redirects for LegacyURL's?*- If you include the LegacyURL field data in the JSON format, this will create
+a RedirectedURL entry for each page imported, redirecting from the LegacyURL to the imported page's url.
+
 
 ## Format
 
-The site tree import module lets you take a tabbed out file of the following format, 
+The site tree import module lets you take a tabbed out file of the following format,
 and load it into your CMS as a site tree.
 
 	Home
-	About
+	About  {"URLSegment": "about-us", "MetaDescription": "About our company"}
 		Staff
 			Sam
 			Sig
@@ -42,9 +51,12 @@ and load it into your CMS as a site tree.
 			Macbook
 			Macbook Pro
 		Phones
-			iPhone
-			
+			iPhone  {"URLSegment": "apple-iphone", "LegacyURL": "/iphones"}
+
 ## Related
 
-See the [static importer module](http://silverstripe.org/static-importer-module/) for a more sophisticated
+See the [static site connector module](http://addons.silverstripe.org/add-ons/silverstripe/staticsiteconnector) for a more sophisticated
 importer based on crawling existing HTML pages, and extracting content via XPATH.
+
+See the [redirected urls module](http://addons.silverstripe.org/add-ons/silverstripe/redirectedurls) for the
+legacy url redirection feature.

--- a/code/SiteTreeImporter.php
+++ b/code/SiteTreeImporter.php
@@ -1,5 +1,20 @@
 <?php
-
+/**
+ * Generate or update pages in the site-tree from a tab indented text file.
+ *
+ * Data fields on the pages can be populated, or updated for existing pages, via
+ * specifying json encoded properties for each item in the tabbed import file.
+ *
+ * URL redirects can be created for each imported page using the LegacyURL json data key,
+ * this feature requires the redirectedurls module.
+ * Optionally, add LegacyURL as a text field in your Page type to display the imported url.
+ *
+ * {@link: https://github.com/silverstripe-labs/silverstripe-redirectedurls}
+ *
+ *
+ * @author Sam Minnée
+ * @author Michael Parkhill
+ */
 class SiteTreeImporter extends Page_Controller {
 	static $allowed_actions = array(
 		'Form',
@@ -19,19 +34,22 @@ class SiteTreeImporter extends Page_Controller {
 		parent::init();
 		if(!Permission::check('ADMIN')) Security::permissionFailure();
 	}
-	
+
 	function Title() {
 		return "Site Tree Importer";
 	}
-	
+
 	function Content() {
 		return <<<HTML
-<p>This tool will let you generate pages from a text file that has a site-tree represented with tabs.  For example, the
-file may contain the following content:</p>
+<p>This tool will let you generate pages from a text file that has a site-tree represented with tabs.</p>
+<p>You can optionally supply JSON encoded data to populate fields in the site-tree pages.</p>
+<p>If your json data contains the key "LegacyURL" then entries will be created in the Redirects module
+for each, this feature assumes the Page db array contains a text field named "LegacyURL".</p>
+<p>For example, the file may contain the following content:</p>
 
 <pre>
 Home
-About
+About {"URLSegment": "about-us", "MetaDescription": "About our company"}
 	Staff
 		Sam
 		Sig
@@ -40,35 +58,40 @@ Products
 		Macbook
 		Macbook Pro
 	Phones
-		iPhone
+		iPhone {"URLSegment": "apple-iphone", "LegacyURL": "/iphones"}
 Contact Us
 </pre>
 
-<p><b>Note:</b> Please make sure that your file contains actual tab character (rather than sequences of spaces), and that there
-is a page called 'Home'.</p>
+<p><b>Note:</b> Please make sure that your file contains actual tab character
+(rather than sequences of spaces), and that there is a page called 'Home'.</p>
 HTML;
 	}
-	
+
 	function Form() {
 		return new Form($this, "Form", new FieldList(
 			new FileField("SourceFile", "Tab-delimited file"),
 			new CheckboxField("DeleteExisting", "Clear out all existing content?"),
-			new CheckboxField("PublishAll", "Publish everything after the import?")
+			new CheckboxField("PublishAll", "Publish everything after the import?"),
+			new CheckboxField("DeleteRedirects", "Clear all all existing Redirects?"),
+			new CheckboxField("CreateRedirects", "Create Redirects for LegacyURL's?")
 		), new FieldList(
 			new FormAction("bulkimport", "Import pages")
 		));
 	}
-	
+
 	function bulkimport($data, $form) {
 		$fh = fopen($data['SourceFile']['tmp_name'],'r');
-
 
 		if(isset($data['DeleteExisting']) && $data['DeleteExisting']) {
 			// TODO Remove subtables
 			DB::query('DELETE FROM "SiteTree"');
 			DB::query('DELETE FROM "SiteTree_Live"');
 		}
-		
+
+		if(class_exists('RedirectedURL') && isset($data['DeleteRedirects']) && $data['DeleteRedirects']) {
+			DB::query('DELETE FROM "RedirectedURL"');
+		}
+
 		Versioned::reading_stage('Stage');
 
 		$parentRefs = array();
@@ -76,60 +99,116 @@ HTML;
 		while($line = fgets($fh, 10000)) {
 			// Skip comments
 			if(preg_match('/^#/', $line)) continue;
-			
+
 			if(preg_match("/^(\t*)([^\t].*)/", $line, $matches)) {
 				$numTabs = strlen($matches[1]);
 				$title = trim($matches[2]);
-				
-				preg_match('/(.*) \(URLSegment: (.*)\)/', $title, $matches);
+				$json = null;
+				$urlsegment = null;
+				$json = null;
+				$decodedJson = null;
+
+				// e.g. http://regexr.com/39u7j
+				preg_match('/(.*)(?:\s)({.*})?$/', $title, $matches);
+
 				if($matches) {
 					$title = $matches[1];
-					$urlsegment = $matches[2];
-				} else {
-					$urlsegment = null;
+					if($matches[2]) {
+						$json = $matches[2];
+						$decodedJson = json_decode($json, true);
+						if(array_key_exists('URLSegment', $decodedJson)) {
+							$urlsegment = $decodedJson['URLSegment'];
+						}
+					}
 				}
 
-				$newPage = ($urlsegment) ? DataObject::get_one('SiteTree', sprintf('"URLSegment" = \'%s\'', $urlsegment)) : null;
-				if(!$newPage) $newPage = new Page();
-				$newPage->Title = $title;
-				$newPage->URLSegment = $urlsegment;
-				
+				// try to find the existing page by matching the URLsegment generated from the imported page title
+				$page = DataObject::get_one('SiteTree', sprintf('"URLSegment"=\'%s\'', Convert::raw2url($title)));
+
+				// page not found, create a new page
+				if(!$page) {
+					$page = new Page();
+					$page->Title = Convert::raw2xml($title);
+					if($urlsegment) {
+						$page->URLSegment = Convert::raw2url($urlsegment);
+					}
+				}
+
 				// If we've got too many tabs, then outdent until we find a page to attach to.
 				while(!isset($parentRefs[$numTabs-1]) && $numTabs > 0) $numTabs--;
 
 				// Set parent based on parentRefs;
-				if($numTabs > 0) $newPage->ParentID = $parentRefs[$numTabs-1];
+				if($numTabs > 0) $page->ParentID = $parentRefs[$numTabs-1];
 
-				$newPage->write();
-				if(isset($data['PublishAll']) && $data['PublishAll']) $newPage->publish('Stage', 'Live');
+				// Apply any json data properties to the page
+				if($decodedJson) {
+					$page->update($decodedJson);
+				}
+
+				$page->write();
+				if(isset($data['PublishAll']) && $data['PublishAll']) $page->publish('Stage', 'Live');
+
+				// create Redirect
+				if($decodedJson && array_key_exists('LegacyURL', $decodedJson)
+					&& isset($data['CreateRedirects']) && $data['CreateRedirects']) {
+					$this->createRedirectedURL($decodedJson['LegacyURL'], null, '/'.$page->RelativeLink());
+				}
 
 				if(!SapphireTest::is_running_test()) {
-					echo"<li>Written #$newPage->ID: $newPage->Title (child of $newPage->ParentID)</li>";
+					echo "<li>Written ID# $page->ID: $page->Title";
+					if($page->ParentID) echo " (ParentID# $page->ParentID)";
+					echo "</li>";
 				}
 
 				// Populate parentRefs with the most recent page at every level.   Necessary to build tree
 				// Children of home should be placed at the top level
 				if(strtolower($title) == 'home') $parentRefs[$numTabs] = 0;
-				else $parentRefs[$numTabs] = $newPage->ID;
+				else $parentRefs[$numTabs] = $page->ID;
 
 				// Remove no-longer-relevant children from the parentRefs.  Allows more graceful acceptance of files
 				// with errors
 				for($i=sizeof($parentRefs)-1;$i>$numTabs;$i--) unset($parentRefs[$i]);
 
 				// Memory cleanup
-				$newPage->destroy();
-				unset($newPage);
+				$page->destroy();
+				unset($page);
 			}
 		}
-		
-		//Director::redirect($this->Link() . 'complete');		
+
+		if(!SapphireTest::is_running_test()) {
+			$complete = $this->complete();
+			echo $complete['Content'];
+		}
+		else {
+			Controller::redirect(Controller::join_links($this->Link(), 'complete'));
+		}
 	}
-	
+
 	function complete() {
 		return array(
 			"Content" => "<p>Thanks! Your site tree has been imported.</p>",
 			"Form" => " ",
 		);
 	}
-	
+
+	/**
+	 * Creates a RedirectedURL data object
+	 *
+	 * @param string $fromBase The relative url to redirect from
+	 * @param string $to The Relative url to redirect to
+	 */
+	protected function createRedirectedURL($fromBase=null, $fromQuerystring=null, $to=null) {
+		if(class_exists('RedirectedURL')) {
+			$redirectedURL = new RedirectedURL();
+			$redirectedURL->FromBase = $fromBase;
+			$redirectedURL->FromQuerystring = $fromQuerystring;
+			$redirectedURL->To = $to;
+			$redirectedURL->write();
+
+			if(!SapphireTest::is_running_test()) {
+				$from = $fromBase . ($fromQuerystring) ? "?".$fromQuerystring : null;
+				echo "<li> Redirect written: $from -> $to </li>";
+			}
+		}
+	}
 }

--- a/tests/SiteTreeImporterTest.php
+++ b/tests/SiteTreeImporterTest.php
@@ -1,23 +1,23 @@
 <?php
 class SiteTreeImporterTest extends FunctionalTest {
-	
+
 	protected $extraDataObjects = array(
 		'SiteTree' // Hack to get SapphireTest refreshing the DB
 	);
-	
+
 	function testImport() {
 		// create sample record
 		$page = new SiteTree();
 		$page->Title = 'ShouldBeExisting';
 		$page->write();
-		
+
 		$data = array();
 		$data['SourceFile'] = array();
 		$data['SourceFile']['tmp_name'] = BASE_PATH . '/sitetreeimporter/tests/SiteTreeImporterTest.txt';
-		
+
 		$importer = singleton('SiteTreeImporter');
 		$importer->bulkimport($data, null);
-	
+
 		$existing = DataObject::get_one('SiteTree', "\"Title\" = 'ShouldBeExisting'");
 		$parent1 = DataObject::get_one('SiteTree', "\"Title\" = 'Parent1'");
 		$parent2 = DataObject::get_one('SiteTree', "\"Title\" = 'Parent2'");
@@ -25,7 +25,7 @@ class SiteTreeImporterTest extends FunctionalTest {
 		$child2_1 = DataObject::get_one('SiteTree', "\"Title\" = 'Child2_1'");
 		$child2_2 = DataObject::get_one('SiteTree', "\"Title\" = 'Child2_2'");
 		$grandchild2_1_1 = DataObject::get_one('SiteTree', "\"Title\" = 'Grandchild2_1_1'");
-		
+
 		$this->assertInstanceOf('SiteTree', $existing);
 		$this->assertInstanceOf('SiteTree', $parent1);
 		$this->assertInstanceOf('SiteTree', $parent2);
@@ -37,23 +37,23 @@ class SiteTreeImporterTest extends FunctionalTest {
 		$this->assertEquals($parent2->ID, $child2_2->ParentID);
 		$this->assertEquals($child2_1->ID, $grandchild2_1_1->ParentID);
 	}
-	
+
 	function testImportPublishAll() {
 		$data = array();
 		$data['PublishAll'] = '1';
 		$data['SourceFile'] = array();
 		$data['SourceFile']['tmp_name'] = BASE_PATH . '/sitetreeimporter/tests/SiteTreeImporterTest.txt';
-		
+
 		$importer = singleton('SiteTreeImporter');
 		$importer->bulkimport($data, null);
-		
+
 		$parent1 = Versioned::get_one_by_stage('SiteTree', 'Live', "\"Title\" = 'Parent1'");
 		$parent2 = Versioned::get_one_by_stage('SiteTree', 'Live', "\"Title\" = 'Parent2'");
 		$parent3 = Versioned::get_one_by_stage('SiteTree', 'Live', "\"Title\" = 'Parent3'");
 		$child2_1 = Versioned::get_one_by_stage('SiteTree', 'Live', "\"Title\" = 'Child2_1'");
 		$child2_2 = Versioned::get_one_by_stage('SiteTree', 'Live', "\"Title\" = 'Child2_2'");
 		$grandchild2_1_1 = Versioned::get_one_by_stage('SiteTree', 'Live', "\"Title\" = 'Grandchild2_1_1'");
-		
+
 		$this->assertInstanceOf('SiteTree', $parent1);
 		$this->assertInstanceOf('SiteTree', $parent2);
 		$this->assertInstanceOf('SiteTree', $parent3);
@@ -61,37 +61,37 @@ class SiteTreeImporterTest extends FunctionalTest {
 		$this->assertInstanceOf('SiteTree', $child2_2);
 		$this->assertInstanceOf('SiteTree', $grandchild2_1_1);
 	}
-	
+
 	function testImportDeleteExisting() {
 		// create sample record
 		$page = new SiteTree();
 		$page->Title = 'ShouldBeDeleted';
 		$page->write();
-		
+
 		$data = array();
 		$data['DeleteExisting'] = '1';
 		$data['SourceFile'] = array();
 		$data['SourceFile']['tmp_name'] = BASE_PATH . '/sitetreeimporter/tests/SiteTreeImporterTest.txt';
-		
+
 		$importer = singleton('SiteTreeImporter');
 		$importer->bulkimport($data, null);
-		
+
 		$this->assertInstanceOf('SiteTree', DataObject::get_one('SiteTree', "\"Title\" = 'Parent1'"));
 		$this->assertFalse(DataObject::get_one('SiteTree', "\"Title\" = 'ShouldBeDeleted'"));
 	}
-	
+
 	function testImportSkipsComments() {
 		$data = array();
 		$data['SourceFile'] = array();
 		$data['SourceFile']['tmp_name'] = BASE_PATH . '/sitetreeimporter/tests/SiteTreeImporterTest.txt';
-		
+
 		$importer = singleton('SiteTreeImporter');
 		$importer->bulkimport($data, null);
-		
+
 		$commentPage = DataObject::get_one('SiteTree', "\"Title\" = '# Comments are skipped'");
 		$this->assertFalse($commentPage);
 	}
-	
+
 	function testImportWithURLSegment() {
 		// create sample record
 		$page = new SiteTree();
@@ -99,17 +99,16 @@ class SiteTreeImporterTest extends FunctionalTest {
 		$page->URLSegment = 'existing';
 		$page->write();
 		$page->publish('Stage', 'Live');
-		
+
 		$data = array();
 		$data['SourceFile'] = array();
 		$data['SourceFile']['tmp_name'] = BASE_PATH . '/sitetreeimporter/tests/SiteTreeImporterTest.txt';
-		
+
 		$importer = singleton('SiteTreeImporter');
 		$importer->bulkimport($data, null);
-		
+
 		$child2_2 = DataObject::get_one('SiteTree', "\"Title\" = 'Child2_2'");
 		$this->assertInstanceOf('SiteTree', $child2_2);
 		$this->assertEquals($child2_2->URLSegment, 'existing');
 	}
 }
-?>

--- a/tests/SiteTreeImporterTest.txt
+++ b/tests/SiteTreeImporterTest.txt
@@ -3,5 +3,5 @@ Parent1
 Parent2
 	Child2_1
 		Grandchild2_1_1
-	Child2_2 (URLSegment: existing)
+	Child2_2 {"URLSegment": "existing", "LegacyURL": "child2_1"}
 Parent3


### PR DESCRIPTION
Added optional support for loading json encoded data attributes that are applied to the objects created by the import.

Also added support for creating url redirects from legacy url strings, specified through the json format. This feature is optional but depends on the silverstripe-labs/redirectedurls module being installed.
