### PR TITLE
update readme legacyUrl code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Home
 ### Redirect URLs
 
 Often an existing tree will need to be imported with URLs which map to different URLs on the new site.
-While you could assign those manually to a `.htaccess` based redirect, we found it useful to 
+While you could assign those manually to a `.htaccess` based redirect, we found it useful to
 store the old URL straight in the `Page` object, and use SilverStripe's routing to handle the redirect.
 
 In this example, we'll use the ["redirected urls" module](http://addons.silverstripe.org/add-ons/silverstripe/redirectedurls),
@@ -76,11 +76,11 @@ class Page extends SiteTree {
 
 		$url = RedirectedURL::get()->find('FromBase', $legacyUrl);
 		if(!$url) {
-			$url = new RedirectedURL();	
+			$url = new RedirectedURL();
 		}
-		
+
 		$url->FromBase = $legacyUrl;
-		$url->To = $this->URLSegment;
+		$url->To = $this->RelativeLink();
 		$url->write();
 	}
 }


### PR DESCRIPTION
Fixes an error in the README code example for creating a RedirectedURL entry. The 'To' field should be populated with a relative url value, not a url segment, as that would not resolve to a page nested below level one in a site-tree.
